### PR TITLE
Use 'open' before set_info when renaming files

### DIFF
--- a/lib/api/rename.js
+++ b/lib/api/rename.js
@@ -24,7 +24,7 @@ module.exports = function(oldPath, newPath, cb){
 
   // SMB2 open the folder / file
   SMB2Request('open_folder', {path:oldPath}, connection, function(err, file){
-    if(err) SMB2Request('create', {path:oldPath}, connection, function(err, file){
+    if(err) SMB2Request('open', {path:oldPath}, connection, function(err, file){
       if(err) cb && cb(err);
       else rename(connection, file, newPath, cb);
     });

--- a/lib/messages/open.js
+++ b/lib/messages/open.js
@@ -20,6 +20,7 @@ module.exports = message({
       }
     , request:{
         'Buffer':buffer
+      , 'DesiredAccess':0x001701DF
       , 'NameOffset':0x0078
       , 'CreateContextsOffset':0x007A+buffer.length
       }


### PR DESCRIPTION
This fixes an issue where using `smb2Client.rename()` to rename a file
results in overwriting the file with empty content before renaming.

The overwrite happens because the 'create' message sets the CreateDisposition option to `FILE_OVERWRITE_IF` (0x00000005) when sending the CREATE request to the smb server.

The DesiredAccess option had to be added to the 'open' message since renaming requires the DELETE permission (I went ahead and used the other additional permissions from the 'open_folder' message).